### PR TITLE
User auth config providers user model

### DIFF
--- a/src/Models/Report.php
+++ b/src/Models/Report.php
@@ -36,7 +36,7 @@ class Report extends Model
 
     public function reporter(): HasOne
     {
-        return $this->hasOne(User::class, 'id', 'reporter_id');
+        return $this->hasOne(config('auth.providers.users.model'), 'id', 'reporter_id');
     }
 
     public function conclusion(): HasOne


### PR DESCRIPTION
Currently it has no namespacing for the class users, so it fails, this will use the configuration set inside the auth.php config under eloquent.